### PR TITLE
addrepository to Cargo.toml

### DIFF
--- a/majordome-cache/Cargo.toml
+++ b/majordome-cache/Cargo.toml
@@ -4,6 +4,7 @@ version = "1.0.2"
 edition = "2021"
 description = "A cache module for Majordome. Currently based on Moka."
 license = "MIT"
+repository = "https://github.com/merlleu/majordome"
 
 [dependencies]
 majordome = "1"

--- a/majordome-derive/Cargo.toml
+++ b/majordome-derive/Cargo.toml
@@ -4,6 +4,7 @@ version = "1.0.2"
 edition = "2021"
 description = "Derive macros for the majordome crate"
 license = "MIT"
+repository = "https://github.com/merlleu/majordome"
 
 [lib]
 proc-macro = true

--- a/majordome/Cargo.toml
+++ b/majordome/Cargo.toml
@@ -4,6 +4,7 @@ version = "1.0.16"
 edition = "2021"
 description = "A modular state manager for Rust API and Services."
 license = "MIT"
+repository = "https://github.com/merlleu/majordome"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.